### PR TITLE
Properly escape words inserted into patterns

### DIFF
--- a/plugin/vim_current_word.vim
+++ b/plugin/vim_current_word.vim
@@ -79,7 +79,7 @@ endfunction
 " Add plugin matches
 function! s:add_current_word_matches()
   if g:vim_current_word#highlight_twins
-    call matchadd('CurrentWordTwins', '\%(\k*\%#\k*\)\@!\<\M'.expand('<cword>').'\m\>', -5, g:vim_current_word#twins_match_id)
+    call matchadd('CurrentWordTwins', '\%(\k*\%#\k*\)\@!\<\V'.substitute(expand('<cword>'), '\\', '\\\\', 'g').'\m\>', -5, g:vim_current_word#twins_match_id)
   endif
   if g:vim_current_word#highlight_current_word
     call matchadd('CurrentWord', '\k*\%#\k*', -4, g:vim_current_word#current_word_match_id)


### PR DESCRIPTION
Words that contain character sequences that have a special meaning in
vim patterns can break the pattern for matching twin words in
`s:add_current_word_matches()` because they are pasted into it without
escaping. This lead to error messages when moving cursor over "words"
like `\+` or `\@>` .
To prevent that "very nomagic" mode is used and all occurrences of `\`
(which is the only character with a special meaning in that mode) are
replaced with `\\` .