### PR TITLE
Call `pre_highlight` also on `BufEnter`

### DIFF
--- a/plugin/vim_current_word.vim
+++ b/plugin/vim_current_word.vim
@@ -9,6 +9,7 @@ let g:vim_current_word#highlight_delay = get(g:, 'vim_current_word#highlight_del
 
 augroup vim_current_word
   autocmd!
+  autocmd BufEnter * call vim_current_word#pre_highlight()
   autocmd CursorMoved * call vim_current_word#pre_highlight()
   autocmd InsertEnter * call vim_current_word#handle_insert_enter()
   autocmd InsertLeave * call vim_current_word#handle_insert_leave()


### PR DESCRIPTION
The `CursorMoved` autocmd is not fired when a user switches the buffer
of the current window and remains at the same cursor position.
Therefore, also bind the `BufEnter` event.